### PR TITLE
feat: ストーリーページに章ナビTOC＋EN/JA言語切り替えを追加

### DIFF
--- a/src/app/story/[slug]/_components/story-reader-ui.tsx
+++ b/src/app/story/[slug]/_components/story-reader-ui.tsx
@@ -1,0 +1,463 @@
+"use client"
+
+import React, { useState, useEffect } from "react"
+import Link from "next/link"
+import Image from "next/image"
+import {
+  ArrowLeft,
+  ArrowRight,
+  BookOpen,
+  Users,
+  Clock,
+  ChevronLeft,
+  ChevronRight,
+  Library,
+} from "lucide-react"
+import { type StoryMeta, type ChapterMeta, getStoriesForEntry, getStoryBySlug } from "@/lib/stories"
+import { type Lang, tl } from "@/lib/lang"
+import ReadingProgress from "./reading-progress"
+import StarField from "./star-field"
+
+/* ─── Wiki name to image mapping ─── */
+const entryImageMap: Record<string, string> = {
+  アイリス: "/edu-iris.png",
+  Diana: "/edu-diana.png",
+  "Kate Claudia": "/edu-kate-claudia.png",
+  "Lily Steiner": "/edu-lillie-steiner.png",
+  "レイラ・ヴィレル・ノヴァ": "/edu-fiona.png",
+  "カステリア・グレンヴェルト": "/edu-diana.png",
+  "シトラ・セレス": "/edu-iris.png",
+  ミュー: "/edu-diana.png",
+  Jen: "/edu-iris.png",
+  "Tina/Gue": "/edu-diana.png",
+  "アルファ・ケイン": "/edu-hero.png",
+  "セリア・ドミニクス": "/edu-celia.png",
+  弦太郎: "/edu-auralis.png",
+  Slime_Woman: "/edu-diana.png",
+  ジュン: "/edu-hero.png",
+  "Kate Patton": "/edu-kate-claudia.png",
+  "Lillie Ardent": "/edu-lillie-steiner.png",
+  "ミナ・エウレカ・エルンスト": "/edu-diana.png",
+  "Ninny Offenbach": "/edu-fiona.png",
+}
+
+function toRoman(n: number): string {
+  const map: [number, string][] = [
+    [10, "X"],
+    [9, "IX"],
+    [5, "V"],
+    [4, "IV"],
+    [1, "I"],
+  ]
+  let result = ""
+  for (const [value, numeral] of map) {
+    while (n >= value) {
+      result += numeral
+      n -= value
+    }
+  }
+  return result
+}
+
+function isSceneBreak(text: string): boolean {
+  const t = text.trim()
+  return (
+    t.startsWith("─") ||
+    t.startsWith("─") ||
+    t.startsWith("==") ||
+    t.startsWith("**") ||
+    t.startsWith("##") ||
+    t.startsWith("＊") ||
+    t.length < 5
+  )
+}
+
+/* ─── Lang Toggle ─── */
+function LangToggle({ lang, setLang }: { lang: Lang; setLang: (l: Lang) => void }) {
+  return (
+    <div className="flex items-center border border-cosmic-border/40 rounded-lg overflow-hidden shrink-0">
+      <button
+        type="button"
+        onClick={() => setLang("ja")}
+        className={`px-2.5 py-1 text-[11px] font-bold transition-colors ${
+          lang === "ja"
+            ? "bg-nebula-purple text-white"
+            : "text-cosmic-muted hover:text-cosmic-text"
+        }`}
+      >
+        JP
+      </button>
+      <button
+        type="button"
+        onClick={() => setLang("en")}
+        className={`px-2.5 py-1 text-[11px] font-bold transition-colors ${
+          lang === "en"
+            ? "bg-nebula-purple text-white"
+            : "text-cosmic-muted hover:text-cosmic-text"
+        }`}
+      >
+        EN
+      </button>
+    </div>
+  )
+}
+
+/* ─── Related Stories Section ─── */
+function RelatedStoriesSection({
+  currentSlug,
+  entryIds,
+  lang,
+}: {
+  currentSlug: string
+  entryIds: string[]
+  lang: Lang
+}) {
+  const relatedSlugs = new Set<string>()
+  entryIds.forEach((eid) => {
+    getStoriesForEntry(eid).forEach((s) => {
+      if (s.slug !== currentSlug) relatedSlugs.add(s.slug)
+    })
+  })
+  const stories = Array.from(relatedSlugs)
+    .map((slug) => getStoryBySlug(slug))
+    .filter(Boolean)
+
+  if (stories.length === 0) return null
+  return (
+    <div className="mt-12 pt-8 border-t border-cosmic-border/30">
+      <h3 className="text-sm font-bold text-cosmic-muted uppercase tracking-wider mb-5 flex items-center gap-2">
+        <BookOpen className="w-4 h-4 text-nebula-purple" />
+        {tl("関連作品", "Related Stories", lang)}
+      </h3>
+      <div className="flex flex-col gap-2">
+        {stories.map(
+          (s) =>
+            s && (
+              <Link
+                key={s.slug}
+                href={`/story/${s.slug}`}
+                className="flex items-center gap-3 px-4 py-3 rounded-xl border border-nebula-purple/15 bg-nebula-purple/5 text-sm text-nebula-purple/90 hover:bg-nebula-purple/10 hover:border-nebula-purple/30 transition-all duration-200 group"
+              >
+                <BookOpen className="w-4 h-4 shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <span className="truncate block group-hover:text-electric-blue transition-colors">
+                    {s.title}
+                  </span>
+                  {s.era && <span className="text-[10px] text-cosmic-muted">{s.era}</span>}
+                </div>
+                <ChevronRight className="w-3 h-3 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+              </Link>
+            )
+        )}
+      </div>
+    </div>
+  )
+}
+
+/* ─── Props ─── */
+export type StoryReaderUIProps = {
+  story: StoryMeta
+  paragraphs: string[]
+  fetchFailed: boolean
+  chapter: ChapterMeta | undefined
+  chapterStories: StoryMeta[]
+  storyIndex: number
+  prev: StoryMeta | null
+  next: StoryMeta | null
+  relatedEntries: Array<{ id: string; name: string }>
+}
+
+/* ─── Main Client Component ─── */
+export function StoryReaderUI({
+  story,
+  paragraphs,
+  fetchFailed,
+  chapter,
+  chapterStories,
+  storyIndex,
+  prev,
+  next,
+  relatedEntries,
+}: StoryReaderUIProps) {
+  const [lang, setLangState] = useState<Lang>("ja")
+
+  useEffect(() => {
+    const saved = localStorage.getItem("edu-lang") as Lang | null
+    if (saved === "en" || saved === "ja") setLangState(saved)
+  }, [])
+
+  const setLang = (l: Lang) => {
+    setLangState(l)
+    localStorage.setItem("edu-lang", l)
+  }
+
+  const chapterLabel =
+    chapter
+      ? tl(
+          `第${toRoman(chapter.id)}章 ${chapter.titleJa}`,
+          `Chapter ${toRoman(chapter.id)} · ${chapter.titleEn}`,
+          lang
+        )
+      : ""
+
+  return (
+    <div className="relative min-h-screen bg-cosmic-dark">
+      <StarField />
+      <ReadingProgress />
+
+      {/* Top Nav */}
+      <nav className="fixed top-0 left-0 right-0 z-50 glass-card border-b border-cosmic-border/50">
+        <div className="max-w-3xl mx-auto px-4">
+          <div className="flex items-center justify-between h-14 gap-3">
+            {/* Left: breadcrumb */}
+            <div className="flex items-center gap-3 min-w-0 flex-1">
+              <Link
+                href="/story"
+                className="flex items-center gap-2 text-cosmic-muted hover:text-electric-blue transition-colors shrink-0"
+              >
+                <ArrowLeft className="w-4 h-4" />
+                <span className="text-xs hidden sm:inline">Story</span>
+              </Link>
+              <span className="text-cosmic-border">/</span>
+              <div className="flex items-center gap-1.5 min-w-0">
+                {chapter && (
+                  <span className="text-[10px] text-cosmic-muted shrink-0">
+                    {toRoman(chapter.id)}
+                  </span>
+                )}
+                <span className="text-xs text-cosmic-muted truncate">
+                  {chapter ? tl(chapter.titleJa, chapter.titleEn, lang) : ""}
+                </span>
+              </div>
+            </div>
+
+            {/* Right: lang toggle + prev/next */}
+            <div className="flex items-center gap-2 shrink-0">
+              <LangToggle lang={lang} setLang={setLang} />
+              {prev && (
+                <Link
+                  href={`/story/${prev.slug}`}
+                  className="w-7 h-7 rounded-lg bg-cosmic-surface/50 border border-cosmic-border/30 flex items-center justify-center text-cosmic-muted hover:text-electric-blue hover:border-electric-blue/30 transition-colors"
+                  title={prev.title}
+                >
+                  <ChevronLeft className="w-3.5 h-3.5" />
+                </Link>
+              )}
+              {next && (
+                <Link
+                  href={`/story/${next.slug}`}
+                  className="w-7 h-7 rounded-lg bg-cosmic-surface/50 border border-cosmic-border/30 flex items-center justify-center text-cosmic-muted hover:text-electric-blue hover:border-electric-blue/30 transition-colors"
+                  title={next.title}
+                >
+                  <ChevronRight className="w-3.5 h-3.5" />
+                </Link>
+              )}
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <main className="relative z-10 pt-24 pb-20 px-4">
+        <div className="max-w-2xl mx-auto">
+          {/* Chapter Indicator */}
+          {chapter && (
+            <div className="mb-8 flex items-center gap-2">
+              <Link
+                href="/story"
+                className="inline-flex items-center gap-1.5 text-[11px] font-medium text-cosmic-muted bg-cosmic-surface/50 border border-cosmic-border/30 rounded-full px-3 py-1 hover:text-electric-blue hover:border-electric-blue/30 transition-colors"
+              >
+                <Library className="w-3 h-3" />
+                {chapterLabel}
+              </Link>
+              <span className="text-[10px] text-cosmic-muted">
+                {storyIndex + 1} / {chapterStories.length}
+              </span>
+            </div>
+          )}
+
+          {/* Story Header */}
+          <header className="mb-12">
+            {chapter && (
+              <div className={`h-0.5 w-16 mb-6 bg-gradient-to-r ${chapter.color} rounded-full`} />
+            )}
+
+            <h1 className="text-2xl sm:text-3xl font-black text-cosmic-text mb-3 leading-tight tracking-tight">
+              {story.title}
+            </h1>
+
+            {story.label !== story.title && (
+              <p className="text-xs text-cosmic-muted mb-4">{story.label}</p>
+            )}
+
+            {story.era && (
+              <div className="flex items-center gap-2 mb-6">
+                <Clock className="w-3.5 h-3.5 text-cosmic-muted" />
+                <span className="text-xs text-cosmic-muted">{story.era}</span>
+              </div>
+            )}
+
+            {/* Related Characters */}
+            <div className="flex flex-wrap gap-2">
+              {relatedEntries.map((entry) => (
+                <Link
+                  key={entry.id}
+                  href={`/wiki/${encodeURIComponent(entry.id)}`}
+                  className="inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium rounded-full border border-nebula-purple/20 bg-nebula-purple/5 text-nebula-purple/80 hover:bg-nebula-purple/15 hover:border-nebula-purple/40 transition-all duration-200"
+                >
+                  <div className="w-5 h-5 rounded-full overflow-hidden border border-nebula-purple/30 bg-cosmic-dark/60 flex items-center justify-center shrink-0">
+                    {entryImageMap[entry.name] ? (
+                      <Image
+                        src={entryImageMap[entry.name]}
+                        alt={entry.name}
+                        width={20}
+                        height={20}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <Users className="w-3 h-3 text-nebula-purple/60" />
+                    )}
+                  </div>
+                  {entry.name}
+                </Link>
+              ))}
+            </div>
+
+            {/* Decorative divider */}
+            <div className="mt-8 flex items-center gap-3">
+              <div className="flex-1 h-px bg-gradient-to-r from-transparent via-cosmic-border/40 to-transparent" />
+              <BookOpen className="w-3 h-3 text-cosmic-border/50" />
+              <div className="flex-1 h-px bg-gradient-to-r from-transparent via-cosmic-border/40 to-transparent" />
+            </div>
+          </header>
+
+          {/* Story Body */}
+          <article className="prose-story">
+            {fetchFailed ? (
+              <p className="text-sm text-cosmic-muted/70 text-center py-12">
+                {tl(
+                  "この作品は現在読み込みできません。後ほど再度お試しください。",
+                  "This story is currently unavailable. Please try again later.",
+                  lang
+                )}
+              </p>
+            ) : (
+              paragraphs.map((p, i) => (
+                <div key={i} className="mb-6">
+                  {isSceneBreak(p) ? (
+                    <div className="flex items-center justify-center py-4">
+                      <div className="w-12 h-px bg-nebula-purple/30" />
+                      <div className="w-1.5 h-1.5 rounded-full bg-nebula-purple/40 mx-3" />
+                      <div className="w-12 h-px bg-nebula-purple/30" />
+                    </div>
+                  ) : (
+                    <p className="text-sm sm:text-base text-cosmic-text/85 leading-[2] text-justify indent-4">
+                      {p.trim()}
+                    </p>
+                  )}
+                </div>
+              ))
+            )}
+          </article>
+
+          {/* Story footer divider */}
+          <div className="mt-12 flex items-center gap-3">
+            <div className="flex-1 h-px bg-gradient-to-r from-transparent via-cosmic-border/40 to-transparent" />
+            <BookOpen className="w-3 h-3 text-cosmic-border/50" />
+            <div className="flex-1 h-px bg-gradient-to-r from-transparent via-cosmic-border/40 to-transparent" />
+          </div>
+
+          {/* Related Stories */}
+          <RelatedStoriesSection
+            currentSlug={story.slug}
+            entryIds={story.relatedEntries}
+            lang={lang}
+          />
+
+          {/* Chapter Navigation */}
+          <div className="mt-12 pt-8 border-t border-cosmic-border/30">
+            <div className="flex items-center justify-between gap-4">
+              {prev ? (
+                <Link
+                  href={`/story/${prev.slug}`}
+                  className="flex-1 group p-4 rounded-xl border border-cosmic-border/20 bg-cosmic-surface/30 hover:bg-cosmic-surface/60 hover:border-nebula-purple/30 transition-all duration-200"
+                >
+                  <div className="flex items-center gap-2 mb-1">
+                    <ArrowLeft className="w-3 h-3 text-cosmic-muted group-hover:text-electric-blue transition-colors" />
+                    <span className="text-[10px] text-cosmic-muted uppercase tracking-wider">
+                      {tl("前の作品", "Previous", lang)}
+                    </span>
+                  </div>
+                  <p className="text-xs font-bold text-cosmic-text group-hover:text-electric-blue transition-colors line-clamp-2">
+                    {prev.title}
+                  </p>
+                </Link>
+              ) : (
+                <div className="flex-1" />
+              )}
+
+              {next ? (
+                <Link
+                  href={`/story/${next.slug}`}
+                  className="flex-1 group p-4 rounded-xl border border-cosmic-border/20 bg-cosmic-surface/30 hover:bg-cosmic-surface/60 hover:border-nebula-purple/30 transition-all duration-200 text-right"
+                >
+                  <div className="flex items-center justify-end gap-2 mb-1">
+                    <span className="text-[10px] text-cosmic-muted uppercase tracking-wider">
+                      {tl("次の作品", "Next", lang)}
+                    </span>
+                    <ArrowRight className="w-3 h-3 text-cosmic-muted group-hover:text-electric-blue transition-colors" />
+                  </div>
+                  <p className="text-xs font-bold text-cosmic-text group-hover:text-electric-blue transition-colors line-clamp-2">
+                    {next.title}
+                  </p>
+                </Link>
+              ) : (
+                <div className="flex-1" />
+              )}
+            </div>
+          </div>
+
+          {/* Back links */}
+          <div className="mt-10 text-center">
+            <Link
+              href="/story"
+              className="inline-flex items-center gap-2 text-xs text-electric-blue hover:underline transition-colors"
+            >
+              <ArrowLeft className="w-3 h-3" />
+              {tl("Story Archive に戻る", "Back to Story Archive", lang)}
+            </Link>
+            {relatedEntries.length > 0 && (
+              <>
+                <span className="text-cosmic-border mx-3">|</span>
+                <Link
+                  href={`/wiki/${encodeURIComponent(relatedEntries[0].id)}`}
+                  className="inline-flex items-center gap-1.5 text-xs text-cosmic-muted hover:text-electric-blue hover:underline transition-colors"
+                >
+                  {tl(
+                    `「${relatedEntries[0].name}」のWiki`,
+                    `${relatedEntries[0].name} Wiki`,
+                    lang
+                  )}
+                </Link>
+              </>
+            )}
+          </div>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="relative border-t border-cosmic-border/50 py-8 px-4">
+        <div className="max-w-3xl mx-auto text-center space-y-2">
+          <div className="w-16 h-0.5 mx-auto bg-gradient-to-r from-transparent via-nebula-purple to-transparent" />
+          <p className="text-xs text-cosmic-muted">EDU Stories — Eternal Dominion Universe</p>
+          <Link
+            href="/story"
+            className="inline-flex items-center gap-1.5 text-xs text-electric-blue hover:underline transition-colors"
+          >
+            <ArrowLeft className="w-3 h-3" />
+            {tl("Story Archive に戻る", "Back to Story Archive", lang)}
+          </Link>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/src/app/story/[slug]/page.tsx
+++ b/src/app/story/[slug]/page.tsx
@@ -1,399 +1,54 @@
 import React from "react"
-import Link from "next/link"
-import Image from "next/image"
 import { notFound } from "next/navigation"
-import {
-  ArrowLeft,
-  ArrowRight,
-  BookOpen,
-  Users,
-  Clock,
-  ChevronLeft,
-  ChevronRight,
-  Library,
-} from "lucide-react"
 import {
   ALL_STORIES,
   CHAPTERS,
   getStoryBySlug,
   getStoryUrl,
-  getStoriesForEntry,
   getStoriesByChapter,
   getAdjacentStories,
 } from "@/lib/stories"
 import { ALL_ENTRIES } from "@/lib/wiki-data"
+import { StoryReaderUI } from "./_components/story-reader-ui"
 
 export function generateStaticParams() {
   return ALL_STORIES.map((s) => ({ slug: s.slug }))
 }
 
-/* ─── Wiki name to image mapping ─── */
-const entryImageMap: Record<string, string> = {
-  アイリス: "/edu-iris.png",
-  Diana: "/edu-diana.png",
-  "Kate Claudia": "/edu-kate-claudia.png",
-  "Lily Steiner": "/edu-lillie-steiner.png",
-  "レイラ・ヴィレル・ノヴァ": "/edu-fiona.png",
-  "カステリア・グレンヴェルト": "/edu-diana.png",
-  "シトラ・セレス": "/edu-iris.png",
-  ミュー: "/edu-diana.png",
-  Jen: "/edu-iris.png",
-  "Tina/Gue": "/edu-diana.png",
-  "アルファ・ケイン": "/edu-hero.png",
-  "セリア・ドミニクス": "/edu-celia.png",
-  弦太郎: "/edu-auralis.png",
-  Slime_Woman: "/edu-diana.png",
-  ジュン: "/edu-hero.png",
-  "Kate Patton": "/edu-kate-claudia.png",
-  "Lillie Ardent": "/edu-lillie-steiner.png",
-  "ミナ・エウレカ・エルンスト": "/edu-diana.png",
-  "Ninny Offenbach": "/edu-fiona.png",
-}
-
-function toRoman(n: number): string {
-  const map: [number, string][] = [
-    [10, "X"],
-    [9, "IX"],
-    [5, "V"],
-    [4, "IV"],
-    [1, "I"],
-  ]
-  let result = ""
-  for (const [value, numeral] of map) {
-    while (n >= value) {
-      result += numeral
-      n -= value
-    }
-  }
-  return result
-}
-
-/* Scene break detection — stable pure function */
-function isSceneBreak(text: string): boolean {
-  const t = text.trim()
-  return (
-    t.startsWith("─") ||
-    t.startsWith("─") ||
-    t.startsWith("==") ||
-    t.startsWith("**") ||
-    t.startsWith("##") ||
-    t.startsWith("＊") ||
-    t.length < 5
-  )
-}
-
-/* ─── Reading Progress (client component) ─── */
-import ReadingProgress from "./_components/reading-progress"
-
-/* ─── Star Field (client component) ─── */
-import StarField from "./_components/star-field"
-
-function RelatedStoriesSection({
-  currentSlug,
-  entryIds,
-}: {
-  currentSlug: string
-  entryIds: string[]
-}) {
-  const relatedSlugs = new Set<string>()
-  entryIds.forEach((eid) => {
-    getStoriesForEntry(eid).forEach((s) => {
-      if (s.slug !== currentSlug) relatedSlugs.add(s.slug)
-    })
-  })
-  const stories = Array.from(relatedSlugs)
-    .map((slug) => getStoryBySlug(slug))
-    .filter(Boolean)
-
-  if (stories.length === 0) return null
-  return (
-    <div className="mt-12 pt-8 border-t border-cosmic-border/30">
-      <h3 className="text-sm font-bold text-cosmic-muted uppercase tracking-wider mb-5 flex items-center gap-2">
-        <BookOpen className="w-4 h-4 text-nebula-purple" />
-        関連作品
-      </h3>
-      <div className="flex flex-col gap-2">
-        {stories.map(
-          (s) =>
-            s && (
-              <Link
-                key={s.slug}
-                href={`/story/${s.slug}`}
-                className="flex items-center gap-3 px-4 py-3 rounded-xl border border-nebula-purple/15 bg-nebula-purple/5 text-sm text-nebula-purple/90 hover:bg-nebula-purple/10 hover:border-nebula-purple/30 transition-all duration-200 group"
-              >
-                <BookOpen className="w-4 h-4 shrink-0" />
-                <div className="flex-1 min-w-0">
-                  <span className="truncate block group-hover:text-electric-blue transition-colors">
-                    {s.title}
-                  </span>
-                  {s.era && <span className="text-[10px] text-cosmic-muted">{s.era}</span>}
-                </div>
-                <ChevronRight className="w-3 h-3 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
-              </Link>
-            )
-        )}
-      </div>
-    </div>
-  )
-}
-
 export default async function StoryPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
   const story = getStoryBySlug(slug)
-  if (!story) notFound()
+  if (!story) return notFound()
 
-  let text = ""
+  let text: string | null = null
   try {
-    const res = await fetch(getStoryUrl(story.fileName), {
-      next: { revalidate: 3600 },
-    })
+    const res = await fetch(getStoryUrl(story.fileName), { next: { revalidate: 3600 } })
     if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
     text = await res.text()
   } catch {
-    text = "この作品は現在読み込みできません。後ほど再度お試しください。"
+    text = null
   }
 
-  const paragraphs = text.split(/\n\n+/).filter((p) => p.trim().length > 0)
-  const relatedEntries = ALL_ENTRIES.filter((e) => story.relatedEntries.includes(e.id))
-
+  const paragraphs = text ? text.split(/\n\n+/).filter((p) => p.trim().length > 0) : []
+  const relatedEntries = ALL_ENTRIES.filter((e) => story.relatedEntries.includes(e.id)).map(
+    (e) => ({ id: e.id, name: e.name })
+  )
   const chapter = CHAPTERS.find((ch) => ch.id === story.chapter)
   const chapterStories = getStoriesByChapter(story.chapter)
   const { prev, next } = getAdjacentStories(story)
   const storyIndex = chapterStories.findIndex((s) => s.slug === story.slug)
 
   return (
-    <div className="relative min-h-screen bg-cosmic-dark">
-      <StarField />
-      <ReadingProgress />
-
-      {/* Top Nav */}
-      <nav className="fixed top-0 left-0 right-0 z-50 glass-card border-b border-cosmic-border/50">
-        <div className="max-w-3xl mx-auto px-4">
-          <div className="flex items-center justify-between h-14">
-            <div className="flex items-center gap-3 min-w-0">
-              <Link
-                href="/story"
-                className="flex items-center gap-2 text-cosmic-muted hover:text-electric-blue transition-colors shrink-0"
-              >
-                <ArrowLeft className="w-4 h-4" />
-                <span className="text-xs hidden sm:inline">Story</span>
-              </Link>
-              <span className="text-cosmic-border">/</span>
-              <div className="flex items-center gap-1.5 min-w-0">
-                {chapter && (
-                  <span className="text-[10px] text-cosmic-muted shrink-0">
-                    {toRoman(chapter.id)}
-                  </span>
-                )}
-                <span className="text-xs text-cosmic-muted truncate">{chapter?.titleJa}</span>
-              </div>
-            </div>
-            <div className="flex items-center gap-2 shrink-0">
-              {prev && (
-                <Link
-                  href={`/story/${prev.slug}`}
-                  className="w-7 h-7 rounded-lg bg-cosmic-surface/50 border border-cosmic-border/30 flex items-center justify-center text-cosmic-muted hover:text-electric-blue hover:border-electric-blue/30 transition-colors"
-                  title={prev.title}
-                >
-                  <ChevronLeft className="w-3.5 h-3.5" />
-                </Link>
-              )}
-              {next && (
-                <Link
-                  href={`/story/${next.slug}`}
-                  className="w-7 h-7 rounded-lg bg-cosmic-surface/50 border border-cosmic-border/30 flex items-center justify-center text-cosmic-muted hover:text-electric-blue hover:border-electric-blue/30 transition-colors"
-                  title={next.title}
-                >
-                  <ChevronRight className="w-3.5 h-3.5" />
-                </Link>
-              )}
-            </div>
-          </div>
-        </div>
-      </nav>
-
-      <main className="relative z-10 pt-24 pb-20 px-4">
-        <div className="max-w-2xl mx-auto">
-          {/* Chapter Indicator */}
-          {chapter && (
-            <div className="mb-8 flex items-center gap-2">
-              <Link
-                href="/story"
-                className="inline-flex items-center gap-1.5 text-[11px] font-medium text-cosmic-muted bg-cosmic-surface/50 border border-cosmic-border/30 rounded-full px-3 py-1 hover:text-electric-blue hover:border-electric-blue/30 transition-colors"
-              >
-                <Library className="w-3 h-3" />第{toRoman(chapter.id)}章 {chapter.titleJa}
-              </Link>
-              <span className="text-[10px] text-cosmic-muted">
-                {storyIndex + 1} / {chapterStories.length}
-              </span>
-            </div>
-          )}
-
-          {/* Story Header */}
-          <header className="mb-12">
-            {chapter && (
-              <div className={`h-0.5 w-16 mb-6 bg-gradient-to-r ${chapter.color} rounded-full`} />
-            )}
-
-            <h1 className="text-2xl sm:text-3xl font-black text-cosmic-text mb-3 leading-tight tracking-tight">
-              {story.title}
-            </h1>
-
-            {story.label !== story.title && (
-              <p className="text-xs text-cosmic-muted mb-4">{story.label}</p>
-            )}
-
-            {story.era && (
-              <div className="flex items-center gap-2 mb-6">
-                <Clock className="w-3.5 h-3.5 text-cosmic-muted" />
-                <span className="text-xs text-cosmic-muted">{story.era}</span>
-              </div>
-            )}
-
-            {/* Related Characters */}
-            <div className="flex flex-wrap gap-2">
-              {relatedEntries.map((entry) => (
-                <Link
-                  key={entry.id}
-                  href={`/wiki/${encodeURIComponent(entry.id)}`}
-                  className="inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium rounded-full border border-nebula-purple/20 bg-nebula-purple/5 text-nebula-purple/80 hover:bg-nebula-purple/15 hover:border-nebula-purple/40 transition-all duration-200"
-                >
-                  <div className="w-5 h-5 rounded-full overflow-hidden border border-nebula-purple/30 bg-cosmic-dark/60 flex items-center justify-center shrink-0">
-                    {entryImageMap[entry.name] ? (
-                      <Image
-                        src={entryImageMap[entry.name]}
-                        alt={entry.name}
-                        width={20}
-                        height={20}
-                        className="w-full h-full object-cover"
-                      />
-                    ) : (
-                      <Users className="w-3 h-3 text-nebula-purple/60" />
-                    )}
-                  </div>
-                  {entry.name}
-                </Link>
-              ))}
-            </div>
-
-            {/* Decorative divider */}
-            <div className="mt-8 flex items-center gap-3">
-              <div className="flex-1 h-px bg-gradient-to-r from-transparent via-cosmic-border/40 to-transparent" />
-              <BookOpen className="w-3 h-3 text-cosmic-border/50" />
-              <div className="flex-1 h-px bg-gradient-to-r from-transparent via-cosmic-border/40 to-transparent" />
-            </div>
-          </header>
-
-          {/* Story Body */}
-          <article className="prose-story">
-            {paragraphs.map((p, i) => (
-              <div key={i} className="mb-6">
-                {isSceneBreak(p) ? (
-                  <div className="flex items-center justify-center py-4">
-                    <div className="w-12 h-px bg-nebula-purple/30" />
-                    <div className="w-1.5 h-1.5 rounded-full bg-nebula-purple/40 mx-3" />
-                    <div className="w-12 h-px bg-nebula-purple/30" />
-                  </div>
-                ) : (
-                  <p className="text-sm sm:text-base text-cosmic-text/85 leading-[2] text-justify indent-4">
-                    {p.trim()}
-                  </p>
-                )}
-              </div>
-            ))}
-          </article>
-
-          {/* Story footer divider */}
-          <div className="mt-12 flex items-center gap-3">
-            <div className="flex-1 h-px bg-gradient-to-r from-transparent via-cosmic-border/40 to-transparent" />
-            <BookOpen className="w-3 h-3 text-cosmic-border/50" />
-            <div className="flex-1 h-px bg-gradient-to-r from-transparent via-cosmic-border/40 to-transparent" />
-          </div>
-
-          {/* Related Stories */}
-          <RelatedStoriesSection currentSlug={slug} entryIds={story.relatedEntries} />
-
-          {/* Chapter Navigation */}
-          <div className="mt-12 pt-8 border-t border-cosmic-border/30">
-            <div className="flex items-center justify-between gap-4">
-              {prev ? (
-                <Link
-                  href={`/story/${prev.slug}`}
-                  className="flex-1 group p-4 rounded-xl border border-cosmic-border/20 bg-cosmic-surface/30 hover:bg-cosmic-surface/60 hover:border-nebula-purple/30 transition-all duration-200"
-                >
-                  <div className="flex items-center gap-2 mb-1">
-                    <ArrowLeft className="w-3 h-3 text-cosmic-muted group-hover:text-electric-blue transition-colors" />
-                    <span className="text-[10px] text-cosmic-muted uppercase tracking-wider">
-                      前の作品
-                    </span>
-                  </div>
-                  <p className="text-xs font-bold text-cosmic-text group-hover:text-electric-blue transition-colors line-clamp-2">
-                    {prev.title}
-                  </p>
-                </Link>
-              ) : (
-                <div className="flex-1" />
-              )}
-
-              {next ? (
-                <Link
-                  href={`/story/${next.slug}`}
-                  className="flex-1 group p-4 rounded-xl border border-cosmic-border/20 bg-cosmic-surface/30 hover:bg-cosmic-surface/60 hover:border-nebula-purple/30 transition-all duration-200 text-right"
-                >
-                  <div className="flex items-center justify-end gap-2 mb-1">
-                    <span className="text-[10px] text-cosmic-muted uppercase tracking-wider">
-                      次の作品
-                    </span>
-                    <ArrowRight className="w-3 h-3 text-cosmic-muted group-hover:text-electric-blue transition-colors" />
-                  </div>
-                  <p className="text-xs font-bold text-cosmic-text group-hover:text-electric-blue transition-colors line-clamp-2">
-                    {next.title}
-                  </p>
-                </Link>
-              ) : (
-                <div className="flex-1" />
-              )}
-            </div>
-          </div>
-
-          {/* Back links */}
-          <div className="mt-10 text-center">
-            <Link
-              href="/story"
-              className="inline-flex items-center gap-2 text-xs text-electric-blue hover:underline transition-colors"
-            >
-              <ArrowLeft className="w-3 h-3" />
-              Story Archive に戻る
-            </Link>
-            {relatedEntries.length > 0 && (
-              <>
-                <span className="text-cosmic-border mx-3">|</span>
-                <Link
-                  href={`/wiki/${encodeURIComponent(relatedEntries[0].id)}`}
-                  className="inline-flex items-center gap-1.5 text-xs text-cosmic-muted hover:text-electric-blue hover:underline transition-colors"
-                >
-                  「{relatedEntries[0].name}」のWiki
-                </Link>
-              </>
-            )}
-          </div>
-        </div>
-      </main>
-
-      {/* Footer */}
-      <footer className="relative border-t border-cosmic-border/50 py-8 px-4">
-        <div className="max-w-3xl mx-auto text-center space-y-2">
-          <div className="w-16 h-0.5 mx-auto bg-gradient-to-r from-transparent via-nebula-purple to-transparent" />
-          <p className="text-xs text-cosmic-muted">EDU Stories — Eternal Dominion Universe</p>
-          <Link
-            href="/story"
-            className="inline-flex items-center gap-1.5 text-xs text-electric-blue hover:underline transition-colors"
-          >
-            <ArrowLeft className="w-3 h-3" />
-            Story Archive に戻る
-          </Link>
-        </div>
-      </footer>
-    </div>
+    <StoryReaderUI
+      story={story}
+      paragraphs={paragraphs}
+      fetchFailed={text === null}
+      chapter={chapter}
+      chapterStories={chapterStories}
+      storyIndex={storyIndex}
+      prev={prev ?? null}
+      next={next ?? null}
+      relatedEntries={relatedEntries}
+    />
   )
 }

--- a/src/app/story/page.tsx
+++ b/src/app/story/page.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import React, { useState, useMemo } from "react"
+import React, { useState, useMemo, useEffect, useRef } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { motion } from "framer-motion"
 import { BookOpen, ArrowLeft, Clock, Users, ChevronDown, Library } from "lucide-react"
 import { ALL_STORIES, CHAPTERS, getStoriesByChapter } from "@/lib/stories"
+import { type Lang, tl } from "@/lib/lang"
 
 /* ─── Wiki name to image mapping ─── */
 const entryImageMap: Record<string, string> = {
@@ -135,15 +136,47 @@ function StarField() {
   )
 }
 
+/* ─── Lang Toggle ─── */
+function LangToggle({ lang, setLang }: { lang: Lang; setLang: (l: Lang) => void }) {
+  return (
+    <div className="flex items-center border border-cosmic-border/40 rounded-lg overflow-hidden shrink-0">
+      <button
+        type="button"
+        onClick={() => setLang("ja")}
+        className={`px-2.5 py-1 text-[11px] font-bold transition-colors ${
+          lang === "ja"
+            ? "bg-nebula-purple text-white"
+            : "text-cosmic-muted hover:text-cosmic-text"
+        }`}
+      >
+        JP
+      </button>
+      <button
+        type="button"
+        onClick={() => setLang("en")}
+        className={`px-2.5 py-1 text-[11px] font-bold transition-colors ${
+          lang === "en"
+            ? "bg-nebula-purple text-white"
+            : "text-cosmic-muted hover:text-cosmic-text"
+        }`}
+      >
+        EN
+      </button>
+    </div>
+  )
+}
+
 /* ─── Story Card ─── */
 function StoryCard({
   story,
   chapter,
   index,
+  lang,
 }: {
   story: (typeof ALL_STORIES)[0]
   chapter: (typeof CHAPTERS)[0]
   index: number
+  lang: Lang
 }) {
   const colors = CHAPTER_COLORS[chapter.id]
   return (
@@ -216,7 +249,7 @@ function StoryCard({
           <span
             className={`inline-flex items-center gap-1 text-xs font-medium ${colors.text} group-hover:gap-2 transition-all`}
           >
-            読む
+            {tl("読む", "Read", lang)}
             <span>→</span>
           </span>
         </div>
@@ -229,15 +262,19 @@ function StoryCard({
 function ChapterSection({
   chapter,
   stories,
+  lang,
+  sectionRef,
 }: {
   chapter: (typeof CHAPTERS)[0]
   stories: (typeof ALL_STORIES)[0][]
+  lang: Lang
+  sectionRef: React.RefObject<HTMLElement | null>
 }) {
   const [isOpen, setIsOpen] = useState(true)
   const colors = CHAPTER_COLORS[chapter.id]
 
   return (
-    <section className="mb-14">
+    <section ref={sectionRef} id={`chapter-${chapter.id}`} className="mb-14 scroll-mt-20">
       {/* Chapter Header */}
       <button
         type="button"
@@ -253,9 +290,11 @@ function ChapterSection({
                 {toRoman(chapter.id)}
               </span>
               <div>
-                <h2 className={`text-lg sm:text-xl font-bold ${colors.text}`}>{chapter.titleJa}</h2>
+                <h2 className={`text-lg sm:text-xl font-bold ${colors.text}`}>
+                  {tl(chapter.titleJa, chapter.titleEn, lang)}
+                </h2>
                 <p className="text-xs text-cosmic-muted tracking-widest uppercase">
-                  {chapter.titleEn}
+                  {tl(chapter.titleEn, chapter.titleJa, lang)}
                 </p>
               </div>
             </div>
@@ -266,10 +305,12 @@ function ChapterSection({
               >
                 {chapter.era}
               </span>
-              <span className="text-[11px] text-cosmic-muted">{stories.length} 作品</span>
+              <span className="text-[11px] text-cosmic-muted">
+                {stories.length} {tl("作品", "stories", lang)}
+              </span>
             </div>
             <p className="text-xs sm:text-sm text-cosmic-muted/80 leading-relaxed max-w-2xl">
-              {chapter.description}
+              {tl(chapter.description, chapter.descriptionEn, lang)}
             </p>
           </div>
           <div
@@ -280,7 +321,7 @@ function ChapterSection({
         </div>
       </button>
 
-      {/* Story Cards Grid — always rendered, visibility via CSS for stability */}
+      {/* Story Cards Grid */}
       <div
         className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 pl-0 sm:pl-2 transition-all duration-300 ${
           isOpen
@@ -289,7 +330,7 @@ function ChapterSection({
         }`}
       >
         {stories.map((story, i) => (
-          <StoryCard key={story.slug} story={story} chapter={chapter} index={i} />
+          <StoryCard key={story.slug} story={story} chapter={chapter} index={i} lang={lang} />
         ))}
       </div>
     </section>
@@ -309,6 +350,30 @@ const chapterData = CHAPTERS.map((ch) => ({
 
 /* ─── Main Page ─── */
 export default function StoryArchivePage() {
+  const [lang, setLangState] = useState<Lang>("ja")
+
+  useEffect(() => {
+    const saved = localStorage.getItem("edu-lang") as Lang | null
+    if (saved === "en" || saved === "ja") setLangState(saved)
+  }, [])
+
+  const setLang = (l: Lang) => {
+    setLangState(l)
+    localStorage.setItem("edu-lang", l)
+  }
+
+  /* Refs for chapter scroll-jump */
+  const chapterRefs = useRef<Record<number, React.RefObject<HTMLElement | null>>>({})
+  for (const { chapter } of chapterData) {
+    if (!chapterRefs.current[chapter.id]) {
+      chapterRefs.current[chapter.id] = React.createRef<HTMLElement>()
+    }
+  }
+
+  function scrollToChapter(id: number) {
+    chapterRefs.current[id]?.current?.scrollIntoView({ behavior: "smooth" })
+  }
+
   return (
     <div className="relative min-h-screen bg-cosmic-dark">
       <StarField />
@@ -316,20 +381,23 @@ export default function StoryArchivePage() {
       {/* Top Nav */}
       <nav className="fixed top-0 left-0 right-0 z-50 glass-card border-b border-cosmic-border/50">
         <div className="max-w-5xl mx-auto px-4">
-          <div className="flex items-center gap-4 h-14">
-            <Link
-              href="/"
-              className="flex items-center gap-2 text-cosmic-muted hover:text-electric-blue transition-colors shrink-0"
-            >
-              <ArrowLeft className="w-4 h-4" />
-              <span className="text-xs hidden sm:inline">EDU</span>
-            </Link>
-            <div className="flex items-center gap-2 min-w-0">
-              <Library className="w-4 h-4 text-nebula-purple shrink-0" />
-              <span className="text-sm font-bold text-cosmic-gradient truncate">
-                EDU Story Archive
-              </span>
+          <div className="flex items-center justify-between gap-4 h-14">
+            <div className="flex items-center gap-4 min-w-0">
+              <Link
+                href="/"
+                className="flex items-center gap-2 text-cosmic-muted hover:text-electric-blue transition-colors shrink-0"
+              >
+                <ArrowLeft className="w-4 h-4" />
+                <span className="text-xs hidden sm:inline">EDU</span>
+              </Link>
+              <div className="flex items-center gap-2 min-w-0">
+                <Library className="w-4 h-4 text-nebula-purple shrink-0" />
+                <span className="text-sm font-bold text-cosmic-gradient truncate">
+                  EDU Story Archive
+                </span>
+              </div>
             </div>
+            <LangToggle lang={lang} setLang={setLang} />
           </div>
         </div>
       </nav>
@@ -341,7 +409,7 @@ export default function StoryArchivePage() {
             initial={{ opacity: 0, y: -20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.7 }}
-            className="text-center mb-16"
+            className="text-center mb-12"
           >
             <div className="w-24 h-0.5 mx-auto bg-gradient-to-r from-transparent via-nebula-purple to-transparent mb-8" />
             <div className="flex items-center justify-center gap-3 mb-4">
@@ -351,8 +419,9 @@ export default function StoryArchivePage() {
               Story Archive
             </h1>
             <p className="text-sm sm:text-base text-cosmic-muted max-w-xl mx-auto leading-relaxed">
-              Eternal Dominion Universe —
-              <br className="sm:hidden" /> 全五章にわたる物語全集
+              Eternal Dominion Universe —{" "}
+              <br className="sm:hidden" />
+              {tl("全五章にわたる物語全集", "A Complete Collection Across Five Chapters", lang)}
             </p>
 
             {/* Stats */}
@@ -360,14 +429,14 @@ export default function StoryArchivePage() {
               <div className="flex flex-col items-center">
                 <span className="text-2xl font-black text-cosmic-text">{CHAPTERS.length}</span>
                 <span className="text-[10px] text-cosmic-muted uppercase tracking-wider">
-                  Chapters
+                  {tl("章", "Chapters", lang)}
                 </span>
               </div>
               <div className="w-px h-10 bg-cosmic-border/50" />
               <div className="flex flex-col items-center">
                 <span className="text-2xl font-black text-cosmic-text">{ALL_STORIES.length}</span>
                 <span className="text-[10px] text-cosmic-muted uppercase tracking-wider">
-                  Stories
+                  {tl("作品", "Stories", lang)}
                 </span>
               </div>
               <div className="w-px h-10 bg-cosmic-border/50" />
@@ -376,33 +445,67 @@ export default function StoryArchivePage() {
                   {uniqueCharacters.size}
                 </span>
                 <span className="text-[10px] text-cosmic-muted uppercase tracking-wider">
-                  Characters
+                  {tl("キャラ", "Characters", lang)}
                 </span>
               </div>
-            </div>
-
-            {/* Chapter Timeline Preview */}
-            <div className="flex justify-center gap-2 mt-8 flex-wrap">
-              {CHAPTERS.map((ch) => (
-                <motion.div
-                  key={ch.id}
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.3 + ch.id * 0.1, duration: 0.4 }}
-                  className={`flex items-center gap-1.5 px-3 py-1 rounded-full border text-[10px] font-medium ${CHAPTER_COLORS[ch.id].badge}`}
-                >
-                  <span className="font-black">{toRoman(ch.id)}</span>
-                  <span className="hidden sm:inline">{ch.titleJa}</span>
-                </motion.div>
-              ))}
             </div>
 
             <div className="w-24 h-0.5 mx-auto bg-gradient-to-r from-transparent via-nebula-purple to-transparent mt-8" />
           </motion.div>
 
+          {/* ─── Chapter Quick Navigation ─── */}
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.3, duration: 0.5 }}
+            className="mb-14"
+          >
+            <div className="flex items-center gap-3 mb-5">
+              <div className="h-px flex-1 bg-cosmic-border/30" />
+              <span className="text-[10px] text-cosmic-muted uppercase tracking-widest font-medium">
+                {tl("章一覧", "Chapter Index", lang)}
+              </span>
+              <div className="h-px flex-1 bg-cosmic-border/30" />
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+              {chapterData.map(({ chapter, stories }) => {
+                const colors = CHAPTER_COLORS[chapter.id]
+                return (
+                  <button
+                    key={chapter.id}
+                    type="button"
+                    onClick={() => scrollToChapter(chapter.id)}
+                    className={`text-left p-4 rounded-xl border glass-card hover:scale-[1.03] hover:shadow-lg transition-all duration-200 group ${colors.border} ${colors.glow}`}
+                  >
+                    <span
+                      className={`text-3xl font-black bg-gradient-to-br ${chapter.color} bg-clip-text text-transparent leading-none block mb-2`}
+                    >
+                      {toRoman(chapter.id)}
+                    </span>
+                    <p className={`text-xs font-bold ${colors.text} leading-tight mb-1`}>
+                      {tl(chapter.titleJa, chapter.titleEn, lang)}
+                    </p>
+                    <p className="text-[10px] text-cosmic-muted">
+                      {chapter.era}
+                    </p>
+                    <p className={`text-[10px] mt-1.5 ${colors.text} opacity-70`}>
+                      {stories.length} {tl("作品", "stories", lang)}
+                    </p>
+                  </button>
+                )
+              })}
+            </div>
+          </motion.div>
+
           {/* Chapter Sections */}
           {chapterData.map((data) => (
-            <ChapterSection key={data.chapter.id} chapter={data.chapter} stories={data.stories} />
+            <ChapterSection
+              key={data.chapter.id}
+              chapter={data.chapter}
+              stories={data.stories}
+              lang={lang}
+              sectionRef={chapterRefs.current[data.chapter.id]}
+            />
           ))}
         </div>
       </main>
@@ -417,7 +520,7 @@ export default function StoryArchivePage() {
             className="inline-flex items-center gap-1.5 text-xs text-electric-blue hover:underline transition-colors"
           >
             <ArrowLeft className="w-3 h-3" />
-            EDU 百科事典に戻る
+            {tl("EDU 百科事典に戻る", "Back to EDU Encyclopedia", lang)}
           </Link>
         </div>
       </footer>

--- a/src/lib/lang.ts
+++ b/src/lib/lang.ts
@@ -1,0 +1,5 @@
+export type Lang = "ja" | "en"
+
+export function tl(ja: string, en: string, lang: Lang): string {
+  return lang === "ja" ? ja : en
+}

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -15,6 +15,7 @@ export interface ChapterMeta {
   titleEn: string
   era: string
   description: string
+  descriptionEn: string
   color: string // tailwind color token for gradient accent
   gradient: string // CSS gradient string for chapter header
 }
@@ -27,6 +28,8 @@ export const CHAPTERS: ChapterMeta[] = [
     era: "E260〜E300",
     description:
       "E16星系への移住から始まる、新天地での最初の物語。ダイアナとケイト・クラウディアたちの初期の足跡が、この世界の基盤を築いていく。",
+    descriptionEn:
+      "The first stories of humanity's new home in the E16 star system. Diana and Kate Claudia lay the foundations of this world in an era of wonder and discovery.",
     color: "from-amber-500 to-orange-600",
     gradient: "linear-gradient(135deg, rgba(245,158,11,0.15) 0%, rgba(249,115,22,0.08) 100%)",
   },
@@ -37,6 +40,8 @@ export const CHAPTERS: ChapterMeta[] = [
     era: "E300〜E400",
     description:
       "英雄たちが次々と覚醒し、ギガポリスの舞台に立つ時代。ネブラ、ジェン、レイラ、弦太郎 — 異なる道を歩む彼らの物語が交錯する。",
+    descriptionEn:
+      "Heroes rise one by one to take the stage of Gigapolis. The paths of Nebura, Jen, Layla, and Gentaro cross in an age of awakening power and converging destinies.",
     color: "from-nebula-purple to-violet-600",
     gradient: "linear-gradient(135deg, rgba(124,58,237,0.15) 0%, rgba(139,92,246,0.08) 100%)",
   },
@@ -47,6 +52,8 @@ export const CHAPTERS: ChapterMeta[] = [
     era: "E400〜",
     description:
       "世界の均衡が崩れ、新たな争いが始まる時代。グエ、ジュンの物語を中心に、激動の時代を生き抜く人々の姿を描く。",
+    descriptionEn:
+      "The balance of the world fractures as new conflicts erupt. Centered on the stories of Gue and Jun, this era chronicles those who survive the chaos of a world in upheaval.",
     color: "from-red-500 to-rose-600",
     gradient: "linear-gradient(135deg, rgba(239,68,68,0.15) 0%, rgba(244,63,94,0.08) 100%)",
   },
@@ -57,6 +64,8 @@ export const CHAPTERS: ChapterMeta[] = [
     era: "E480〜",
     description:
       "アイリスをはじめとする新世代の英雄が、星々の歴史を受け継ぎ新たな章を開く。カステリア、シトラ、ミュー — 個性豊かな物語が紡がれる。",
+    descriptionEn:
+      "A new generation led by Iris inherits the history of the stars and opens a fresh chapter. Casteria, Sitra, and Myu each weave their own distinct and vibrant tale.",
     color: "from-electric-blue to-cyan-500",
     gradient: "linear-gradient(135deg, rgba(56,189,248,0.15) 0%, rgba(6,182,212,0.08) 100%)",
   },
@@ -67,6 +76,8 @@ export const CHAPTERS: ChapterMeta[] = [
     era: "E520〜",
     description:
       "AURALISの誕生と、最新の時代を彩る物語。ミナ、ニニー、パットン、アーデント — 新世界の幕開けを告げるスピンオフ群。",
+    descriptionEn:
+      "The birth of AURALIS and the stories that color the newest era. Kate Patton, Lillie Ardent, Mina, and Ninny herald the dawn of a new world through their spinoff tales.",
     color: "from-emerald-500 to-teal-500",
     gradient: "linear-gradient(135deg, rgba(16,185,129,0.15) 0%, rgba(20,184,166,0.08) 100%)",
   },


### PR DESCRIPTION
- src/lib/lang.ts: Lang型とtl()ヘルパー関数を追加
- src/lib/stories.ts: ChapterMetaにdescriptionEn（英語章説明）を追加
- story/page.tsx: 章TOC（クイックジャンプナビ）を追加、JP/ENトグル実装、 全UIテキストを言語対応化、localStorageで言語設定を永続化
- story/[slug]/page.tsx: データ取得をServer Componentに残しUIをクライアントへ分離
- story-reader-ui.tsx: ストーリーリーダーのクライアントコンポーネント新設、 JP/ENトグルボタン、章ラベル・前後ナビ・関連作品等を言語対応化

https://claude.ai/code/session_01PCf8d9McnJcYLd8XhZPwgC