### PR TITLE
fix: ページ表示バグ4件修正

### DIFF
--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -25,7 +25,7 @@ export default function CharactersPage() {
         cards: cards.sort((a, b) => {
           const rarityOrder = { SR: 0, R: 1, C: 2 }
           if (rarityOrder[a.rarity] !== rarityOrder[b.rarity]) return rarityOrder[a.rarity] - rarityOrder[b.rarity]
-          return (b.attack + b.defense + b.effectValue + b.ultimate) - (a.attack + a.defense + a.effectValue + b.ultimate)
+          return (b.attack + b.defense + b.effectValue + b.ultimate) - (a.attack + a.defense + a.effectValue + a.ultimate)
         }),
       }))
   })()

--- a/src/app/factions/page.tsx
+++ b/src/app/factions/page.tsx
@@ -21,7 +21,7 @@ function FactionNode({
     <div className="flex gap-4">
       <div className="flex flex-col items-center">
         <div className={`w-3 h-3 rounded-full ${dotColor} shrink-0`} />
-        {!isLast && <div className={`w-0.5 flex-1 min-h-[24px] ${color} opacity-30`} />}
+        {!isLast && <div className={`w-0.5 flex-1 min-h-[24px] ${color.replace("border-", "bg-")} opacity-30`} />}
       </div>
       <div className="pb-4">
         <span className="text-xs text-cosmic-muted">{node.year}</span>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 import { Noto_Sans_JP } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
@@ -30,7 +31,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang="ja" className="dark" suppressHydrationWarning>

--- a/src/components/edu/page-header.tsx
+++ b/src/components/edu/page-header.tsx
@@ -1,11 +1,12 @@
 "use client"
+import type { ReactNode } from "react"
 import Link from "next/link"
 import { ChevronLeft } from "lucide-react"
 
-export function PageHeader({ icon, title, subtitle, wikiHref }: { 
-  icon: React.ReactNode; 
-  title: React.ReactNode; 
-  subtitle?: React.ReactNode;
+export function PageHeader({ icon, title, subtitle, wikiHref }: {
+  icon: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
   wikiHref?: string;
 }) {
   return (


### PR DESCRIPTION
- factions/page.tsx: ノード間コネクタ縦線のCSSクラスをborder-*からbg-*に変更（線が不可視だった）
- characters/page.tsx: 勢力別ソート比較式のb.ultimateをa.ultimateに修正（タイポによる誤ソート）
- layout.tsx: React.ReactNodeをReactNodeに変更し import type { ReactNode } を追加
- page-header.tsx: React.ReactNodeをReactNodeに変更し import type { ReactNode } を追加

https://claude.ai/code/session_01N14HUhx11yTLCVNTTeYojK